### PR TITLE
Show final rtt result in bold

### DIFF
--- a/jishaku/features/management.py
+++ b/jishaku/features/management.py
@@ -167,8 +167,11 @@ class ManagementFeature(Feature):
 
             if api_readings:
                 average, stddev = mean_stddev(api_readings)
-
-                text += f"\n\nAverage: {average * 1000:.2f} \N{PLUS-MINUS SIGN} {stddev * 1000:.2f}ms"
+                average_str = f"\n\nAverage: {average * 1000:.2f} \N{PLUS-MINUS SIGN} {stddev * 1000:.2f}ms"
+                if _ < 5:
+                    text += average_str
+                else:
+                    text += f"**{average_str)**"
             else:
                 text += "\n\nNo readings yet."
 


### PR DESCRIPTION
## Rationale

<!-- What is the reason behind this change? How does implementing it benefit end users or contributors? -->
Just to make the `rtt` command slightly more intuitive, this change will make the final reading of the average latency show in bold text.

## Summary of changes made
After the 5th reading, show the average result in bold markdown text.
<!-- An explanation, in plain English, of your implementation of this change. -->

## Checklist

<!-- To check a box, place an x in the box (with no spaces), like so: [x] -->

- [x] This PR changes the jishaku module/cog codebase
    - [ ] These changes add new functionality to the module/cog
    - [ ] These changes fix an issue or bug in the module/cog
    - [ ] I have tested that these changes work on a production bot codebase
    - [ ] I have tested these changes against the CI/CD test suite
    - [ ] I have updated the documentation to reflect these changes
- [ ] This PR changes the CI/CD test suite
    - [ ] I have tested my suite changes are well-formed (all tests can be discovered)
    - [ ] These changes adjust existing test cases
    - [ ] These changes add new test cases
- [ ] This PR changes prose (such as the documentation, README or other Markdown/RST documents)
    - [ ] I have proofread my changes for grammar and spelling issues
    - [ ] I have tested that any changes regarding Markdown/RST syntax result in a well formed document
